### PR TITLE
Выполнил ДЗ kubernetes-network

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -15,6 +15,12 @@ spec:
   containers:
   - name: web
     image: dookee/app:web
+    livenessProbe:
+        tcpSocket: { port: 8000 }
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 80
     volumeMounts:
     - name: app
       mountPath: /app

--- a/kubernetes-networks/README
+++ b/kubernetes-networks/README
@@ -1,0 +1,88 @@
+Работа с тестовым веб-приложением
+- Добавление проверок Pod
+Добавлены в web-pod.yaml:
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 80
+Результат kubectl get pod/web:
+NAME   READY   STATUS    RESTARTS   AGE
+web    0/1     Running   0          2m31s
+
+Результат kubectl describe pod/web:
+Conditions:
+  Type              Status
+  Initialized       True
+  Ready             False
+  ContainersReady   False
+  PodScheduled      True
+События:
+  Normal   Started    55s               kubelet            Started container web
+  Warning  Unhealthy  3s (x8 over 54s)  kubelet            Readiness probe failed: Get "http://10.244.0.49:80/index.html": dial tcp 10.244.0.49:80: connect: connection refused
+Добавлено в web-pod.yaml
+livenessProbe:
+    tcpSocket: { port: 8000 }
+Применить конфигурацию не удалось из-за ошибки. Пришлось использовать опцию --force.
+- Создание объекта Deployment
+Создан web-deployment.yaml
+Выполнены рекомендации по заполнению файла
+Копирован в template конфигурация пода из web-pod.yaml
+Под не запустился из-за ошибки
+  Warning  Unhealthy  0s (x11 over 77s)  kubelet            Readiness probe failed: Get "http://10.244.0.51:80/index.html": dial tcp 10.244.0.51:80: connect: connection refused
+Изменил порт с 80 на 8000 в readinessProbe и кол-во replicas с 1 на 3 в файле по рекомендации.
+
+Применил deployment
+❯ kubectl apply -f web-deploy.yaml
+deployment.apps/web configured
+- Добавление сервисов в кластер ( ClusterIP )
+Создал и приминил манифест web-svc-cip.yaml для сервиса в директории kubernetes-networks
+Проверил результат
+❯ kubectl get services
+NAME          TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
+kubernetes    ClusterIP   10.96.0.1      <none>        443/TCP   13d
+web-svc-cip   ClusterIP   10.98.244.17   <none>        80/TCP    63m
+
+Выполнил curl http://10.98.244.17/index.html, команда выполнилась успешно
+ping не прошел на указанные адрес, как и указано в материале.
+arp -en
+root@minikube:~# arp -en | grep 10.98.244.17
+root@minikube:~# 
+root@minikube:~# ip addr show | grep 10.98.244.17
+root@minikube:~# 
+root@minikube:~# iptables --list -nv -t nat | grep 10.98.244.17
+    0     0 KUBE-SVC-6CZTMAROCN3AQODZ  tcp  --  *      *       0.0.0.0/0            10.98.244.17         /* default/web-svc-cip cluster IP */ tcp dpt:80
+   11   660 KUBE-MARK-MASQ  tcp  --  *      *      !10.244.0.0/16        10.98.244.17         /* default/web-svc-cip cluster IP */ tcp dpt:80
+
+- Включение режима балансировки IPVS
+Выключил minikube и запустил новый с параметром  --extra-config=kube-proxy.proxy-mode=ipvs
+Исправил ConfigMap
+ipvs:       
+  strictARP: true
+mode: "ipvs"
+Удалил под kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
+После выполнения команды minikube ssh и выполнения команды iptables --list -nv -t nat получил ошибку:
+docker@minikube:~$ iptables --list -nv -t nat
+Fatal: can't open lock file /run/xtables.lock: Permission denied
+Очевидно проблема в том, что требуется выполнить sudo su -
+Выполнил sudo su - команда iptables --list -nv -t nat выполнилась
+Создал файл /tmp/iptables.cleanup с инструкциями и применил командой iptables-restore
+Настроил MetalLB, добавил маршрут. Всё работает.
+Через configmap реализовать создание пула адресов не удалось. Большая часть ссылок в методичке не работает.
+Настроил lb для получения адреса из имени в кластере coredns
+
+❯ kubectl describe ingress web
+Name:             web
+Labels:           <none>
+Namespace:        default
+Address:          192.168.49.2
+....
+
+❯ curl https://172.17.255.2/web/index.html -k
+<html>
+<head/>
+<body>
+<!-- IMAGE BEGINS HERE -->
+<font size="-3">
+...
+
+Все остальное тоже было выполнено.

--- a/kubernetes-networks/canary/canary-dep-svc-ing.yaml
+++ b/kubernetes-networks/canary/canary-dep-svc-ing.yaml
@@ -1,0 +1,81 @@
+# Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: canary
+  namespace: canary
+  labels:
+    app: canary
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: canary
+  template:
+    metadata:
+      labels:
+        app: canary
+    spec:
+      containers:
+      - name: canary
+        image: registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4
+        ports:
+        - containerPort: 80
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+---
+# Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: canary
+  namespace: canary
+  labels:
+    app: canary
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: canary
+---
+# Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: canary
+  namespace: canary
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: echo.test.canary
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: canary
+            port:
+              number: 80

--- a/kubernetes-networks/canary/main-dep-svc-ing.yaml
+++ b/kubernetes-networks/canary/main-dep-svc-ing.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: canary
+  labels:
+    name: canary
+---
+# Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: production
+  namespace: canary
+  labels:
+    app: production
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: production
+  template:
+    metadata:
+      labels:
+        app: production
+    spec:
+      containers:
+      - name: production
+        image: registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4
+        ports:
+        - containerPort: 80
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+---
+# Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: production
+  namespace: canary
+  labels:
+    app: production
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: production
+---
+# Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: production
+  namespace: canary
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: echo.test.canary
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: production
+            port:
+              number: 80

--- a/kubernetes-networks/coredns/coredns.yaml
+++ b/kubernetes-networks/coredns/coredns.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "service-dns-lb"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dnstcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "service-dns-lb"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dnsudp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/kubernetes-networks/dashboard/k8s-dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/k8s-dashboard-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ redirect;
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: kubernetes-dashboard
+            port:
+              number: 443

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: config
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.17.255.1-172.17.255.255
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2-advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - config

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      initContainers:
+      - name: init-web
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      containers:
+      - name: web
+        image: dookee/app:web
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+            tcpSocket: { port: 8000 }        
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+      

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /web
+            pathType: Prefix
+            backend:
+              service: 
+                name: web-svc
+                port: 
+                  number: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [Выполнено] Основное ДЗ
 - [Выполнено] Задание со *

## В процессе сделано:
Работа с тестовым веб-приложением
- Добавление проверок Pod
Добавлены в web-pod.yaml:
    readinessProbe:
      httpGet:
        path: /index.html
        port: 80
Результат kubectl get pod/web:
NAME   READY   STATUS    RESTARTS   AGE
web    0/1     Running   0          2m31s

Результат kubectl describe pod/web:
Conditions:
  Type              Status
  Initialized       True
  Ready             False
  ContainersReady   False
  PodScheduled      True
События:
  Normal   Started    55s               kubelet            Started container web
  Warning  Unhealthy  3s (x8 over 54s)  kubelet            Readiness probe failed: Get "http://10.244.0.49:80/index.html": dial tcp 10.244.0.49:80: connect: connection refused
Добавлено в web-pod.yaml
livenessProbe:
    tcpSocket: { port: 8000 }
Применить конфигурацию не удалось из-за ошибки. Пришлось использовать опцию --force.
- Создание объекта Deployment
Создан web-deployment.yaml
Выполнены рекомендации по заполнению файла
Копирован в template конфигурация пода из web-pod.yaml
Под не запустился из-за ошибки
  Warning  Unhealthy  0s (x11 over 77s)  kubelet            Readiness probe failed: Get "http://10.244.0.51:80/index.html": dial tcp 10.244.0.51:80: connect: connection refused
Изменил порт с 80 на 8000 в readinessProbe и кол-во replicas с 1 на 3 в файле по рекомендации.

Применил deployment
❯ kubectl apply -f web-deploy.yaml
deployment.apps/web configured
- Добавление сервисов в кластер ( ClusterIP )
Создал и приминил манифест web-svc-cip.yaml для сервиса в директории kubernetes-networks
Проверил результат
❯ kubectl get services
NAME          TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
kubernetes    ClusterIP   10.96.0.1      <none>        443/TCP   13d
web-svc-cip   ClusterIP   10.98.244.17   <none>        80/TCP    63m

Выполнил curl http://10.98.244.17/index.html, команда выполнилась успешно
ping не прошел на указанные адрес, как и указано в материале.
arp -en
root@minikube:~# arp -en | grep 10.98.244.17
root@minikube:~# 
root@minikube:~# ip addr show | grep 10.98.244.17
root@minikube:~# 
root@minikube:~# iptables --list -nv -t nat | grep 10.98.244.17
    0     0 KUBE-SVC-6CZTMAROCN3AQODZ  tcp  --  *      *       0.0.0.0/0            10.98.244.17         /* default/web-svc-cip cluster IP */ tcp dpt:80
   11   660 KUBE-MARK-MASQ  tcp  --  *      *      !10.244.0.0/16        10.98.244.17         /* default/web-svc-cip cluster IP */ tcp dpt:80

- Включение режима балансировки IPVS
Выключил minikube и запустил новый с параметром  --extra-config=kube-proxy.proxy-mode=ipvs
Исправил ConfigMap
ipvs:       
  strictARP: true
mode: "ipvs"
Удалил под kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
После выполнения команды minikube ssh и выполнения команды iptables --list -nv -t nat получил ошибку:
docker@minikube:~$ iptables --list -nv -t nat
Fatal: can't open lock file /run/xtables.lock: Permission denied
Очевидно проблема в том, что требуется выполнить sudo su -
Выполнил sudo su - команда iptables --list -nv -t nat выполнилась
Создал файл /tmp/iptables.cleanup с инструкциями и применил командой iptables-restore
Настроил MetalLB, добавил маршрут. Всё работает.
Через configmap реализовать создание пула адресов не удалось. Большая часть ссылок в методичке не работает.
Настроил lb для получения адреса из имени в кластере coredns

❯ kubectl describe ingress web
Name:             web
Labels:           <none>
Namespace:        default
Address:          192.168.49.2
....

❯ curl https://172.17.255.2/web/index.html -k
<html>
<head/>
<body>
<!-- IMAGE BEGINS HERE -->
<font size="-3">
...

Все остальное тоже было выполнено.
